### PR TITLE
Fixing installed apps settings to prevent clashes between app labels

### DIFF
--- a/campusromero_openedx_extensions/__init__.py
+++ b/campusromero_openedx_extensions/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for campusromero_openedx_extensions.
 """
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/campusromero_openedx_extensions/settings/devstack.py
+++ b/campusromero_openedx_extensions/settings/devstack.py
@@ -13,10 +13,19 @@ def plugin_settings(settings):
     # Setting the installed apps inside the campus romero plugin.
     # Please add those ones via ansible to ADDL_INSTALLED_APPS on production environment
     settings.INSTALLED_APPS = getattr(settings, 'INSTALLED_APPS', [])
-    settings.INSTALLED_APPS += [
+
+    # Preventing clashes with already added installed apps
+    PLUGIN_INSTALLED_APPS = [
         "campusromero_openedx_extensions.custom_registration_form",
         "campusromero_openedx_extensions.user_import_export",
+        "import_export",
+        "rangefilter",
     ]
+
+    for single_app in PLUGIN_INSTALLED_APPS:
+        if single_app not in settings.INSTALLED_APPS:
+            settings.INSTALLED_APPS.append(single_app)
+
     # Settings for custom registration form.
     # Please add this via ansible on prod environments
     settings.REGISTRATION_EXTENSION_FORM = "campusromero_openedx_extensions.custom_registration_form.forms.CustomForm"


### PR DESCRIPTION
This fix was created because a problem we had on an environment that defined the installed apps required for the plugin on the lms.env.json file, and the plugin were adding the required installed apps again via devstack settings file. Now it only adds the apps if these were not defined previously.

@Alec4r 
@Squirrel18 