### PR TITLE
Redirect to course mode selection from Marketing site

### DIFF
--- a/campusromero_openedx_extensions/general_custom_views/templates/general_custom_views/purchase_course.html
+++ b/campusromero_openedx_extensions/general_custom_views/templates/general_custom_views/purchase_course.html
@@ -119,7 +119,7 @@ color: #fff;}
             url: "change_enrollment",
             data: $('#class_enroll_form').serialize(),
             success: function(data){
-                window.location.href = "/course_modes/choose/${ cod_course }/";
+                window.top.location.href = "/course_modes/choose/${ cod_course }/";
             },
         });
     });


### PR DESCRIPTION
Redirecting to the right LMS page to select course mode when enrolling a paid course with audit seat available.

Basically when you are on the marketing site, you can enroll in a paid course that offers an audit mode:

![Screenshot from 2019-12-04 15-58-42](https://user-images.githubusercontent.com/15217219/70181138-5935b000-16af-11ea-9012-0d3e9abb1f48.png)

Once you click the button to enroll (which is an iframe), you must be redirected to a page in the LMS to select if you want to continue as an audit student or pay for the course:

![Screenshot from 2019-12-04 15-59-02](https://user-images.githubusercontent.com/15217219/70181280-9f8b0f00-16af-11ea-9c87-0c054a7e1648.png)

That redirect is performed by the iframe included as the Enroll button in the marketing site. We need to use `window.top` to make sure the location of the first parent page (in this case, the marketing site) is being changed.

@cocococosti 
@amalbas 
@morenol 