### PR TITLE
fix: update requirements version for juniper migration

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,6 @@
 openpyxl<3.0.0
-django-admin-rangefilter==0.5.1
-django-import-export==1.2.0
+django-admin-rangefilter==0.8.1
+django-import-export==2.5.0
 qrcode==6.1
+tablib==2.0.0
+et-xmlfile==1.0.1


### PR DESCRIPTION
I set the versions of tablib and et-xmlfile and update the library versions to a newer one that still supports Python 3.5