### PR TITLE
fix: added app_namespace and on_delete that was needed for django (juniper migration)

### DIFF
--- a/campusromero_openedx_extensions/custom_registration_form/migrations/0001_initial.py
+++ b/campusromero_openedx_extensions/custom_registration_form/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('dni', models.TextField(max_length=30, verbose_name='DNI')),
                 ('phone_number', models.CharField(max_length=60, verbose_name='Phone Number')),
                 ('institution', models.TextField(max_length=60, verbose_name='Institution')),
-                ('user', models.OneToOneField(null=True, to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(null=True, to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/campusromero_openedx_extensions/custom_registration_form/models.py
+++ b/campusromero_openedx_extensions/custom_registration_form/models.py
@@ -18,7 +18,7 @@ class CustomFormFields(models.Model):
     Holds extra info to be, used during
     user registration as a form extension.
     """
-    user = models.OneToOneField(USER_MODEL, null=True)
+    user = models.OneToOneField(USER_MODEL, null=True, on_delete=models.CASCADE)
     month_of_birth = models.CharField(
         verbose_name=_("Month Of Birth"),
         blank=True,

--- a/campusromero_openedx_extensions/general_custom_views/api/urls.py
+++ b/campusromero_openedx_extensions/general_custom_views/api/urls.py
@@ -7,8 +7,9 @@ urlpatterns = [  # pylint: disable=invalid-name
     url(
         r'^v1/',
         include(
-            'campusromero_openedx_extensions.general_custom_views.api.v1.urls',
-            namespace='camrom-api'
+            ('campusromero_openedx_extensions.general_custom_views.api.v1.urls',
+            'camrom-api'),
+            namespace='camrom-api',
         )
     ),
 ]


### PR DESCRIPTION
- I added the app_namespace that was needed [(doc)](https://docs.djangoproject.com/en/3.2/ref/urls/#include)
- Now the on_delete is needed in OneToOne fields, and it is cascade because it was what was by default before. [(doc)](https://docs.djangoproject.com/en/3.2/ref/models/fields/#arguments)