### PR TITLE
fix: display the province field in registration form

### DIFF
--- a/campusromero_openedx_extensions/custom_registration_form/forms.py
+++ b/campusromero_openedx_extensions/custom_registration_form/forms.py
@@ -45,3 +45,4 @@ class CustomForm(ModelForm):
         self.fields['province'].error_messages = {
             'invalid': _('This province is not valid, please check your input.'),
         }
+        self.fields['province'].required = True


### PR DESCRIPTION
Added `self.fields['province'].required = True` in forms.py to display the province field in registration form