### PR TITLE
fix: removes encoding from email template body

### DIFF
--- a/campusromero_openedx_extensions/general_custom_views/views.py
+++ b/campusromero_openedx_extensions/general_custom_views/views.py
@@ -295,25 +295,25 @@ class contactanos(APIView):
 
         body = EMAIL_TEMPLATE.replace(
             '{nombreCompleto}',
-            nombreCompleto.encode('utf-8')
+            nombreCompleto
         ).replace(
             '{email}',
-            email.encode('utf-8')
+            email
         ).replace(
             '{region}',
-            region.encode('utf-8')
+            region
         ).replace(
             '{curso}',
-            curso.encode('utf-8')
+            curso
         ).replace(
             '{telefono}',
-            telefono.encode('utf-8')
+            telefono
         ).replace(
             '{tema}',
-            tema.encode('utf-8')
+            tema
         ).replace(
             '{descripcion}',
-            descripcion.encode('utf-8')
+            descripcion
         )
 
         enviarMail(email, str(body), nombreCompleto)


### PR DESCRIPTION
**Description**
This PR fixes the following:
![image](https://user-images.githubusercontent.com/64440265/137132923-f6482067-1594-4c18-9a71-09b5b9b93ef2.png)

After the change:
![image](https://user-images.githubusercontent.com/64440265/137133051-e4717997-127b-43b4-8225-16fda57315f4.png)

**Rationale**
The `encode` method converts `str` into `bytes`, but then those `bytes` need to be inserted into `EMAIL_TEMPLATE` (therefore need to be of type `str` so `replace` works)

**How to replicate tests**
1. Setup a SMTP server, I used [mailtrap](https://mailtrap.io/). 
2. Modify lines 232-235 in campusromero_openedx_extensions/general_custom_views/views.py, with the mailtrap config information
3. POST /contactanos